### PR TITLE
feat: replace playwright-cli with agent-browser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,24 +285,23 @@ Each MCP tool domain lives in its own file under `agent-runner/src/mcp-*.ts`. To
 4. Register it in `agent-runner/src/index.ts` under `mcpServers` with `command: "node", args: ["/app/mcp-{domain}.js"]`
 5. The `allowedTools` wildcard `"mcp__praktor-*"` covers all `praktor-*` named servers automatically
 
-## Browser Automation (playwright-cli)
+## Browser Automation (agent-browser)
 
-All agent containers include [playwright-cli](https://github.com/microsoft/playwright-cli) (`@playwright/cli`) pre-installed and configured to use the system Chromium on Alpine. Agents interact with browsers via Bash commands (more token-efficient than MCP).
+All agent containers include [agent-browser](https://github.com/vercel-labs/agent-browser) built from source and configured to use the system Chromium on Alpine. Agents interact with browsers via Bash commands (more token-efficient than MCP).
 
 **Build-time setup** (`Dockerfile.agent`):
-- Separate `playwright-cli` build stage installs `@playwright/cli` globally and runs `playwright-cli install --skills --config` to extract the skill files without downloading browsers
-- The `@playwright` node_modules and skill directory are copied to the runtime image at `/usr/local/lib/node_modules/@playwright` and `/opt/playwright-cli/skill/`
-- A `cli.config.json` is generated at `/opt/playwright-cli/cli.config.json` pointing to `/usr/bin/chromium-browser` with `--no-sandbox`, `--disable-gpu`, `--disable-dev-shm-usage`
-- `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1` and `PLAYWRIGHT_BROWSERS_PATH=/usr/bin` env vars prevent Playwright from downloading its own browsers
+- Separate `rust-build` stage clones the repo and compiles the native Rust CLI via `cargo build --release` on Alpine (musl-compatible binary)
+- The compiled binary is copied to `/usr/local/bin/agent-browser` and the skill directory to `/opt/agent-browser/skill/`
+- A `config.json` is generated at `/opt/agent-browser/config.json` pointing to system Chromium at `/usr/bin/chromium-browser`
 
-**Runtime setup** (`agent-runner/src/index.ts` → `setupPlaywrightCli()`):
-- Symlinks `/opt/playwright-cli/skill` → `/home/praktor/.claude/skills/playwright-cli` (skill loaded into system prompt)
-- Symlinks `/opt/playwright-cli/cli.config.json` → `/workspace/agent/.playwright/cli.config.json` (playwright-cli resolves config relative to cwd)
+**Runtime setup** (`agent-runner/src/index.ts` → `setupAgentBrowser()`):
+- Symlinks `/opt/agent-browser/skill` → `/home/praktor/.claude/skills/agent-browser` (skill loaded into system prompt)
+- Symlinks `/opt/agent-browser/config.json` → `/home/praktor/.agent-browser/config.json` (agent-browser resolves config from `~/.agent-browser/`)
 - Symlinks (not copies) ensure agents always use the image's version — updates come from rebuilding the image
 
-**Browser lifecycle:** The browser session persists across messages within the same agent session. Agents use tabs (`tab-new`, `tab-close`) for multiple pages. Everything shuts down with the container on idle timeout.
+**Browser lifecycle:** The browser session persists across messages within the same agent session. Everything shuts down with the container on idle timeout.
 
-**System prompt:** When `/opt/playwright-cli` exists, a prompt section tells agents that playwright-cli is pre-installed and to never install playwright/chromium via npm, npx, or nix.
+**System prompt:** When `/opt/agent-browser` exists, a prompt section tells agents that agent-browser is pre-installed and to never install browsers via npm, npx, or nix.
 
 ## What it supports
 
@@ -316,7 +315,7 @@ All agent containers include [playwright-cli](https://github.com/microsoft/playw
 - Nix package manager - Agents with `nix_enabled: true` can install packages on demand via MCP tools (nix_search, nix_add, nix_list_installed, nix_remove, nix_upgrade). When nix-daemon is detected, the system prompt instructs agents to auto-install missing tools. The `/nix` Telegram command provides direct user control over agent packages.
 - File sending - Agents can send files (screenshots, PDFs, etc.) to Telegram via the `file_send` MCP tool. Images are sent as photos, other files as documents. Max 12MB per file.
 - File receiving - Files sent to the bot in Telegram (documents, photos, audio, video, voice, video notes, animations) are downloaded and saved to the agent's workspace at `/workspace/agent/uploads/{timestamp}_{filename}`. The agent receives the file path in the message. Supports Telegram's 20MB download limit.
-- Browser automation - [playwright-cli](https://github.com/microsoft/playwright-cli) pre-installed with system Chromium, skill auto-loaded into system prompt. Browser session persists across messages, shuts down with container.
+- Browser automation - [agent-browser](https://github.com/vercel-labs/agent-browser) pre-installed with system Chromium, skill auto-loaded into system prompt. Browser session persists across messages, shuts down with container.
 - Container isolation - Agents sandboxed in Docker containers with NATS communication
 - Agent swarms - Graph-based orchestration: fan-out (parallel), pipeline (sequential with context passing), and collaborative (real-time chat) execution patterns. Visual graph editor in Mission Control, `@swarm` Telegram integration
 - Secure vault - AES-256-GCM encrypted secrets, injected as env vars or files at container start (never exposed to LLM)

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -6,14 +6,12 @@ RUN go mod download
 RUN CGO_ENABLED=0 go build -o /ptask ./cmd/ptask
 RUN CGO_ENABLED=0 go run ./cmd/getcc -save /claude
 
-# Install playwright-cli and extract its skill
-FROM node:24-alpine AS playwright-cli
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-RUN npm install -g @playwright/cli@latest
-# Install skills only, skip browser download (--config flag skips ensureConfiguredBrowserInstalled)
-RUN mkdir -p /tmp/.playwright && cd /tmp && playwright-cli install --skills --config
-# Verify skill was created
-RUN test -f /tmp/.claude/skills/playwright-cli/SKILL.md
+# Build agent-browser from source (produces musl-compatible Rust binary)
+FROM rust:1.94-alpine AS rust-build
+RUN apk add --no-cache git
+RUN git clone https://github.com/vercel-labs/agent-browser /agent-browser
+WORKDIR /agent-browser
+RUN cargo build --release --manifest-path cli/Cargo.toml
 
 # Bundle agent runner with esbuild (no node_modules needed at runtime)
 FROM node:24-alpine AS agent-builder
@@ -63,21 +61,16 @@ RUN adduser \
 COPY --from=agent-builder /app/out/ /app/
 COPY --from=go-build /ptask /usr/local/bin/ptask
 COPY --from=go-build /claude /usr/local/bin/claude
-COPY --from=playwright-cli /usr/local/lib/node_modules/@playwright /usr/local/lib/node_modules/@playwright
-RUN ln -s ../lib/node_modules/@playwright/cli/playwright-cli.js /usr/local/bin/playwright-cli
-COPY --from=playwright-cli /tmp/.claude/skills/playwright-cli/ /opt/playwright-cli/skill/
-RUN echo '{"browser":{"browserName":"chromium","launchOptions":{"executablePath":"/usr/bin/chromium-browser","args":["--no-sandbox","--disable-gpu","--disable-dev-shm-usage"]}}}' \
-    > /opt/playwright-cli/cli.config.json
+COPY --from=rust-build /agent-browser/cli/target/release/agent-browser /usr/local/bin/agent-browser
+COPY --from=rust-build /agent-browser/skills/agent-browser/ /opt/agent-browser/skill/
+RUN echo '{"native":true,"contentBoundaries":true,"downloadPath":"/workspace/agent/Downloads","executable-path":"/usr/bin/chromium-browser","args":"--no-sandbox,--disable-gpu,--disable-dev-shm-usage"}' \
+    > /opt/agent-browser/config.json
 
 # Pre-create volume mount points with correct ownership so Docker
 # populates new named volumes with the right permissions and structure.
 RUN mkdir -p /workspace/agent /workspace/global /home/praktor/bin && \
     chown -R praktor:praktor /workspace/agent /workspace/global /home/praktor/bin && \
     chmod 0700 /home/praktor
-
-# playwright-cli env vars (skip browser download — we use system chromium)
-ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
-ENV PLAYWRIGHT_BROWSERS_PATH=/usr/bin
 
 # Runtime config
 ENV USE_BUILTIN_RIPGREP=0

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A single Go binary that orchestrates the full loop: receives messages from Teleg
 - **User profile** — Agents know who you are via `USER.md`, editable from Mission Control or by agents themselves
 - **Scheduled tasks** — Cron, interval, or one-shot jobs that run agents and deliver results via Telegram
 - **Secure vault** — AES-256-GCM encrypted secrets injected as env vars or files at container start, never exposed to the LLM
-- **Web & browser access** — Agents can search the web and automate browsers via [playwright-cli](https://github.com/microsoft/playwright-cli)
+- **Web & browser access** — Agents can search the web and automate browsers via [agent-browser](https://github.com/vercel-labs/agent-browser)
 - **Hot config reload** — Edit `praktor.yaml` and changes apply automatically, no restart needed
 - **Nix package manager** — Agents can install packages on demand (Python, ffmpeg, LaTeX, etc.) via MCP tools or the `/nix` Telegram command
 - **Agent extensions** — Per-agent MCP servers, plugins, and skills, managed via Mission Control
@@ -178,16 +178,16 @@ agents:
 
 ## Browser Automation
 
-All agent containers come with [playwright-cli](https://github.com/microsoft/playwright-cli) pre-installed and configured to use system Chromium. Agents can navigate websites, fill forms, take screenshots, and extract data — no setup needed.
+All agent containers come with [agent-browser](https://github.com/vercel-labs/agent-browser) pre-installed and configured to use system Chromium. The native Rust CLI is built from source during the Docker build for musl/Alpine compatibility. Agents can navigate websites, fill forms, take screenshots, and extract data — no setup needed.
 
 The browser session persists across messages within the same agent session and shuts down with the container on idle timeout.
 
 ```
-@general take a screenshot of https://example.com
+@general open https://example.com and tell me what you see
 @general go to https://example.com/form, fill in the email field, and submit
 ```
 
-The playwright-cli skill is automatically loaded into every agent's system prompt, teaching it the full command set (`open`, `goto`, `click`, `fill`, `screenshot`, `snapshot`, tabs, etc.).
+The agent-browser skill is automatically loaded into every agent's system prompt, teaching it the full command set (`open`, `snapshot`, `click`, `fill`, `screenshot`, sessions, etc.).
 
 ## Agent Extensions
 

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -88,27 +88,27 @@ function ensureAgentMd(): void {
   }
 }
 
-function setupPlaywrightCli(): void {
-  const optDir = "/opt/playwright-cli";
-  if (!existsSync(optDir)) return; // playwright-cli not baked into image
+function setupAgentBrowser(): void {
+  const optDir = "/opt/agent-browser";
+  if (!existsSync(optDir)) return; // agent-browser not baked into image
 
   try {
     // Symlink skill directory
-    const skillLink = "/home/praktor/.claude/skills/playwright-cli";
+    const skillLink = "/home/praktor/.claude/skills/agent-browser";
     mkdirSync("/home/praktor/.claude/skills", { recursive: true });
     if (existsSync(skillLink)) rmSync(skillLink, { recursive: true });
     symlinkSync(join(optDir, "skill"), skillLink);
 
-    // Symlink cli.config.json (playwright-cli resolves config relative to cwd)
-    const configDir = "/workspace/agent/.playwright";
-    const configLink = join(configDir, "cli.config.json");
+    // Symlink config.json (agent-browser resolves from ~/.agent-browser/config.json)
+    const configDir = "/home/praktor/.agent-browser";
     mkdirSync(configDir, { recursive: true });
+    const configLink = join(configDir, "config.json");
     if (existsSync(configLink)) rmSync(configLink);
-    symlinkSync(join(optDir, "cli.config.json"), configLink);
+    symlinkSync(join(optDir, "config.json"), configLink);
 
-    console.log("[agent] playwright-cli configured");
+    console.log("[agent] agent-browser configured");
   } catch (err) {
-    console.warn("[agent] could not configure playwright-cli:", err);
+    console.warn("[agent] could not configure agent-browser:", err);
   }
 }
 
@@ -208,15 +208,14 @@ function loadSystemPrompt(includeIdentity = true): string {
     console.warn("[agent] could not load memory keys:", err);
   }
 
-  // playwright-cli: inform agent it's pre-installed with system chromium
-  if (existsSync("/opt/playwright-cli")) {
+  // agent-browser: inform agent it's pre-installed with system chromium
+  if (existsSync("/opt/agent-browser")) {
     parts.push(
-      "PLAYWRIGHT-CLI — Pre-installed and configured. Do NOT install playwright or chromium via npm, npx, nix, or any other method.\n" +
-      "- `playwright-cli` is already in PATH and ready to use.\n" +
-      "- It is configured to use the system chromium at `/usr/bin/chromium-browser`.\n" +
-      "- Just run `playwright-cli open` to start a browser session.\n" +
-      "- The browser persists across messages. Reuse the existing session — use tabs (`tab-new`, `tab-close`) for multiple pages.\n" +
-      "- Do NOT run `playwright-cli close` or `playwright-cli close-all` — the browser will shut down with the container."
+      "AGENT-BROWSER — Pre-installed and configured. Do NOT install browsers via npm, npx, nix, or any other method.\n" +
+      "- `agent-browser` is already in PATH and ready to use.\n" +
+      "- It is configured to use the system Chromium at `/usr/bin/chromium-browser`.\n" +
+      "- Run `agent-browser open <url>` to start a browser session, then `agent-browser snapshot -i` to see the page.\n" +
+      "- The browser persists across messages. Reuse the existing session."
     );
   }
 
@@ -523,7 +522,7 @@ async function main(): Promise<void> {
 
   installGlobalInstructions();
   ensureAgentMd();
-  setupPlaywrightCli();
+  setupAgentBrowser();
 
   // Apply agent extensions (MCP servers, plugins, skills, settings)
   const extResult = await applyExtensions();

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -221,7 +221,8 @@ function loadSystemPrompt(includeIdentity = true): string {
       "- `agent-browser` is already in PATH and ready to use.\n" +
       "- It is configured to use the system Chromium at `/usr/bin/chromium-browser`.\n" +
       "- Run `agent-browser open <url>` to start a browser session, then `agent-browser snapshot -i` to see the page.\n" +
-      "- The browser persists across messages. Reuse the existing session."
+      "- The browser persists across messages. Reuse the existing session.\n" +
+      "- When executing a scheduled task, ALWAYS run `agent-browser close` when done to free resources."
     );
   }
 


### PR DESCRIPTION
## Summary

- Replace playwright-cli (`@playwright/cli`) with [agent-browser](https://github.com/vercel-labs/agent-browser) (native Rust CLI built from source on Alpine for musl compatibility)
- Config served via `~/.agent-browser/config.json` symlinked at container startup
- Update system prompt: instruct agents to close browser after scheduled tasks
- Update CLAUDE.md and README.md documentation

## Test plan

- [ ] `docker compose build agent` succeeds
- [ ] Send message to agent: "open https://example.com and tell me what you see"
- [ ] Agent uses `agent-browser open` and `agent-browser snapshot` successfully
- [ ] Verify no chromium zombies after browser use
- [ ] Scheduled task with browser closes browser on completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)