### PR TITLE
chore(deps): bump claude-agent-sdk to 0.3.150 and claude CLI to 2.1.150

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ ui/node_modules/
 ui/dist/
 agent-runner/node_modules/
 agent-runner/dist/
+agent-runner/out/
 config/praktor.yaml
 .env
 docker-compose.override.yml

--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -10,7 +10,7 @@ RUN node esbuild.mjs
 
 FROM ghcr.io/mtzanidakis/praktor-agent-base:latest
 COPY --from=agent-builder /app/out/ /app/
-RUN /usr/local/bin/getcc -get-version 2.1.143 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
+RUN /usr/local/bin/getcc -get-version 2.1.150 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
 USER praktor
 WORKDIR /workspace/agent
 ENTRYPOINT ["tini", "--", "node", "/app/index.mjs"]

--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,7 +8,7 @@
       "name": "praktor-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.143",
+        "@anthropic-ai/claude-agent-sdk": "0.3.150",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "nats": "latest"
       },
@@ -20,22 +20,22 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.143.tgz",
-      "integrity": "sha512-JnxOTRpSBpFqKFMfV5cW4QjpeDOHUNr31rRislmOVWEPsRmCjsy9jYwKxDf7kxcwxyZ6h/YHz1ACvMaUWy6o6A==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.150.tgz",
+      "integrity": "sha512-/RgkK5eTgIbzw5VRvH+T/hWeC5P7dCoYEO5ZWlwTSqvjfdVFOZhkiUKf4gz0ONpeLORAetqWU4rIfcVjQAH5fg==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.143",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.143"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.150"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.143.tgz",
-      "integrity": "sha512-41WuTuP+bk4NxrjpG9IJGffsjh1ivyiiAmqgb5QoxPltDAA0p3gs+iZ3lTgDmY4Ga68wDoN05Lt18oCE+DQb7g==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.150.tgz",
+      "integrity": "sha512-YVWJ0MHdSy0tobHO2G5/+vd9iRGyosg3wM6sY4pirezsnwZJBkJv/9IeVIaKqdLv83OA6HUcxxOLGzKSBawq2Q==",
       "cpu": [
         "arm64"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.143.tgz",
-      "integrity": "sha512-3WrJ6MjjwQKvPnPbzUOm08qftlHYobkp/tmM1P/Vk/ldSjoPfFIgLFfzSzUmCKJiKEh2ZlHLJr8ORNrTxXhgQg==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.150.tgz",
+      "integrity": "sha512-72M8mKCa7Tfy66G5hr5z9TirKynQa9sFj+4qDxkAp5LAYnyViUzHOqO6mEjVtwDr2aXnjqkhTdBtc5Hmn1m/nA==",
       "cpu": [
         "x64"
       ],
@@ -70,9 +70,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.143.tgz",
-      "integrity": "sha512-/9oP/FCewrPnwVN+QUS5rlO3kMa07w+hOrpWrz24aEpBYhcHzr0zoNMBriPDAkTr3ao/z1k40UZ2dHmgsSODzA==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.150.tgz",
+      "integrity": "sha512-1nhCXjfbxwhQPTgx2+q8lFYHx8DGJEOdaSd4wLvhGJifd/9QJwtnxaill1q+qdggZDroXHDJOTugttP0be6diA==",
       "cpu": [
         "arm64"
       ],
@@ -86,9 +86,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.143.tgz",
-      "integrity": "sha512-9UeV1W2vjOVwJSJrq9aw3UeMo82Ir59FfJ5mchh7OXZEaevkANvHYn25bTCnIpqfqOx7qFEosJW2ELIoV1nprg==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.150.tgz",
+      "integrity": "sha512-KxkrUkGRhVcj4/2LkLrhVcEPl+6McDvtpZlgikHwAczVIf7aCvh01w2meEvuNjvex3dCv0d8CT+WYWxKJUhsbw==",
       "cpu": [
         "arm64"
       ],
@@ -102,9 +102,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.143.tgz",
-      "integrity": "sha512-kwqnbHo4Zj6TzO1V/83uLhsTt0xBp/BN5V/aHIX+khM4UuNO6NOKNaZvr8Int3sF0ARF95Hjr4l/hMKxry6DhQ==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.150.tgz",
+      "integrity": "sha512-G7yOB9O6twOhQH3SvZWIvOcjehfA0HD5f/j49Z/yxZK5U72hOxtnbx7GCbcH/8AyB7JFyHjHpR9hxOxFoJNIhQ==",
       "cpu": [
         "x64"
       ],
@@ -118,9 +118,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.143.tgz",
-      "integrity": "sha512-rr4334GOLl9caYDeyWsbwMaVJCiNvKHE9nLdey8opIkq7/FHHu712U6tDk0tcoCdsGU/S3/BBaZParOgF+s5qw==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.150.tgz",
+      "integrity": "sha512-cm+kWR077H4+ZaMPtqrHosjsVba9hjfn31gtK7D96ziz9Mzn/XhkAz68oObDOTBDqj4j+JbmAHSl5JvyGMHcAg==",
       "cpu": [
         "x64"
       ],
@@ -134,9 +134,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.143.tgz",
-      "integrity": "sha512-q5UaLZ9ABbqQN8UXpqHUqjW6akI1zMrV5Jvtq0yueKP4nIRbBBZBQ80M4bpdrc0+SiRmjVRV3p8lsCCAd8azgg==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.150.tgz",
+      "integrity": "sha512-z9vlm3JdOQ1Vqj9sG8kW+r9miunv4UFQOn0AqoI++J9AgoCBjKGCH2WWmZYhGOvezZqogunXaTciJvhtDhJiWQ==",
       "cpu": [
         "arm64"
       ],
@@ -147,9 +147,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.143",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.143.tgz",
-      "integrity": "sha512-46L2mkskvIRfwzHP3p0uUE5u9Oc7Eb/DRVmXuGNk5Z8jiahlDSv0SHP1vnWSWw5nWIu4DWOKyXZelRmYc9LxCg==",
+      "version": "0.3.150",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.150.tgz",
+      "integrity": "sha512-lpAVi7tZdHi3BXRWmCVmOE2O8q7nzbvuMneYKS9rkpIbcjMjOBk6ud/rlp8Cuiqmp4LzZ8ylbbI7vFEiylK6Hg==",
       "cpu": [
         "x64"
       ],

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.143",
+    "@anthropic-ai/claude-agent-sdk": "0.3.150",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "nats": "latest"
   },

--- a/mise.toml
+++ b/mise.toml
@@ -4,3 +4,6 @@ golangci-lint = "2.12.2"
 node = "24"
 "aqua:nats-io/natscli" = "latest"
 jq = "latest"
+
+[settings]
+node.compile = false


### PR DESCRIPTION
## Summary

- Bump `@anthropic-ai/claude-agent-sdk` from 0.3.143 → 0.3.150 (latest).
- Bump pinned Claude CLI in `Dockerfile.agent` from 2.1.143 → 2.1.150.
- Add `[settings] node.compile = false` to `mise.toml` so future `mise install` runs download prebuilt node binaries instead of compiling from source.
- Add `agent-runner/out/` (esbuild output) to `.gitignore`.

## Release notes 0.3.144 → 0.3.150

All additive or version-parity bumps:
- **0.3.144** — new `model_not_found` error type; new `extractFromBunfs` export for `bun build --compile` consumers.
- **0.3.145 – 0.3.148** — parity with claude-code versions.
- **0.3.149** — fixed `options.env` dropping `CLAUDE_AGENT_SDK_VERSION`; corrected docs (env *replaces* subprocess env, doesn't merge with `process.env`). Doesn't affect us — we don't pass `env` on the top-level `query()` options.
- **0.3.150** — parity with claude-code 2.1.150.

## Test plan

- [x] `npm install` clean
- [x] `node esbuild.mjs` (runs `tsc --noEmit` first) — clean compile, 8 bundles
- [x] `npx vitest run` — 7 files, 66 tests pass
- [ ] Build agent image and smoke-test a real message

🤖 Generated with [Claude Code](https://claude.com/claude-code)