### PR TITLE
chore: bump claude-agent-sdk to 0.3.156, claude code to 2.1.156

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -10,7 +10,7 @@ RUN node esbuild.mjs
 
 FROM ghcr.io/mtzanidakis/praktor-agent-base:latest
 COPY --from=agent-builder /app/out/ /app/
-RUN /usr/local/bin/getcc -get-version 2.1.150 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
+RUN /usr/local/bin/getcc -get-version 2.1.156 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
 USER praktor
 WORKDIR /workspace/agent
 ENTRYPOINT ["tini", "--", "node", "/app/index.mjs"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ agents:
     nix_enabled: true
   coder:
     description: "Software engineering specialist"
-    model: "claude-opus-4-7"
+    model: "claude-opus-4-8"
     nix_enabled: true
     env:
       GITHUB_TOKEN: "secret:github-token"    # Resolved from vault

--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,34 +8,34 @@
       "name": "praktor-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.150",
+        "@anthropic-ai/claude-agent-sdk": "0.3.156",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "nats": "*"
+        "nats": "latest"
       },
       "devDependencies": {
         "@types/node": "latest",
-        "esbuild": "*",
-        "typescript": "*",
+        "esbuild": "latest",
+        "typescript": "latest",
         "vitest": "latest"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.150.tgz",
-      "integrity": "sha512-/RgkK5eTgIbzw5VRvH+T/hWeC5P7dCoYEO5ZWlwTSqvjfdVFOZhkiUKf4gz0ONpeLORAetqWU4rIfcVjQAH5fg==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.156.tgz",
+      "integrity": "sha512-6nM/Dj+VMds52UXJ2YaV4IKhYamlUqN0HtdDrFzYz5lvPMpDS935qD8YZDAUpy+ltdoD6PJMd1V/CKFY3/oWCQ==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.150",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.150",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.150",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.150",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.150",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.150",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.150",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.150"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.156",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.156",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.156",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.156",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.156",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.156",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.156",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.156"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.150.tgz",
-      "integrity": "sha512-YVWJ0MHdSy0tobHO2G5/+vd9iRGyosg3wM6sY4pirezsnwZJBkJv/9IeVIaKqdLv83OA6HUcxxOLGzKSBawq2Q==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.156.tgz",
+      "integrity": "sha512-IkjcS9dqAUlD4Nb62L9AZtmAXCa+FV4ul8lIlyXXUprh3nlecbKsWOXVd/GORrzAhMmynJaX4+iV1JiutFKXUA==",
       "cpu": [
         "arm64"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.150.tgz",
-      "integrity": "sha512-72M8mKCa7Tfy66G5hr5z9TirKynQa9sFj+4qDxkAp5LAYnyViUzHOqO6mEjVtwDr2aXnjqkhTdBtc5Hmn1m/nA==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.156.tgz",
+      "integrity": "sha512-6PKi5fPmGRuzXu+Em/iwLmPG3mqg0hl92wcTU8fmChqyNtxhxsjCw7LTbdFqp/05o5NeZVVV4k3p7YUv5IFD6g==",
       "cpu": [
         "x64"
       ],
@@ -70,11 +70,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.150.tgz",
-      "integrity": "sha512-1nhCXjfbxwhQPTgx2+q8lFYHx8DGJEOdaSd4wLvhGJifd/9QJwtnxaill1q+qdggZDroXHDJOTugttP0be6diA==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.156.tgz",
+      "integrity": "sha512-H0Nfd41iw5isto9uQI1FlVSZ0eaDttr8rBpJMR25oK/mj3egMO5EmZ6aAxeeUYSLn2mSU50HA5VNxlGUE118TQ==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -83,11 +86,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.150.tgz",
-      "integrity": "sha512-KxkrUkGRhVcj4/2LkLrhVcEPl+6McDvtpZlgikHwAczVIf7aCvh01w2meEvuNjvex3dCv0d8CT+WYWxKJUhsbw==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.156.tgz",
+      "integrity": "sha512-R7KEVjxkR4rYgIQoHGBzwPdUJYxRTO8I4vHjRbMLH1eW4FS7BJvVs7ogfKR/NnHFBvMVqtC+l6jHLQv8bobUiw==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -96,11 +102,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.150.tgz",
-      "integrity": "sha512-G7yOB9O6twOhQH3SvZWIvOcjehfA0HD5f/j49Z/yxZK5U72hOxtnbx7GCbcH/8AyB7JFyHjHpR9hxOxFoJNIhQ==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.156.tgz",
+      "integrity": "sha512-ymhrdlbWoYvTACUdaGdhrEv+ZMfwXLsf0BRLkr/IvY5aqybP7URzWmmZGOtDQpqkT/8xu/UCGqUYH3woJwUxfg==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "glibc"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -109,11 +118,14 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.150.tgz",
-      "integrity": "sha512-cm+kWR077H4+ZaMPtqrHosjsVba9hjfn31gtK7D96ziz9Mzn/XhkAz68oObDOTBDqj4j+JbmAHSl5JvyGMHcAg==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.156.tgz",
+      "integrity": "sha512-/Q6WUizI6a+hqZZ6ElwRU0PEuFhOoN4v6CuU35HHbiZ/7uaocGht4A8ZIgK1Fw6wOGtZzGLbc00CA1OU1Zg8EA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "SEE LICENSE IN LICENSE.md",
       "optional": true,
@@ -122,9 +134,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.150.tgz",
-      "integrity": "sha512-z9vlm3JdOQ1Vqj9sG8kW+r9miunv4UFQOn0AqoI++J9AgoCBjKGCH2WWmZYhGOvezZqogunXaTciJvhtDhJiWQ==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.156.tgz",
+      "integrity": "sha512-5sAeNObQQrMy4NF9HwxewrMnU7mVxZDHh+/MfJVQSz0GSTvXQ6gOuRH8helMlfspoU6VOdekPxVLRooX/3foEw==",
       "cpu": [
         "arm64"
       ],
@@ -135,9 +147,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.150",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.150.tgz",
-      "integrity": "sha512-lpAVi7tZdHi3BXRWmCVmOE2O8q7nzbvuMneYKS9rkpIbcjMjOBk6ud/rlp8Cuiqmp4LzZ8ylbbI7vFEiylK6Hg==",
+      "version": "0.3.156",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.156.tgz",
+      "integrity": "sha512-/PofeTWoiKgnWNSNk0wG4SsRn22GGLmnLhg2R94WcNhCRFOyOTmiZcYH2DBlWZBIRVTZDsSfa/Pl1DyPvYCGKw==",
       "cpu": [
         "x64"
       ],

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.150",
+    "@anthropic-ai/claude-agent-sdk": "0.3.156",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "nats": "latest"
   },

--- a/config/praktor.example.yaml
+++ b/config/praktor.example.yaml
@@ -18,7 +18,7 @@ agents:
     # agentmail_inbox_id: "general@agentmail.to"  # AgentMail inbox (optional)
   coder:
     description: "Software engineering specialist"
-    model: "claude-opus-4-7"
+    model: "claude-opus-4-8"
     workspace: coder
     nix_enabled: true                              # Enable nix package manager
     env:


### PR DESCRIPTION
## Changes

- Bump `@anthropic-ai/claude-agent-sdk` 0.3.150 → 0.3.156 (supersedes #179)
- Bump Claude CLI 2.1.150 → 2.1.156 (`Dockerfile.agent`)
- Update example config and README default model from `claude-opus-4-7` to `claude-opus-4-8`

🤖 Generated with [Claude Code](https://claude.com/claude-code)