### PR TITLE
agent-browser v0.28.0: switch to typed MCP interface (drop Bash + skill)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -332,6 +332,8 @@ All agent containers include [agent-browser](https://github.com/vercel-labs/agen
 
 **System prompt:** When `/usr/local/bin/agent-browser` exists, a prompt section tells agents that agent-browser is pre-installed and to never install browsers via npm, npx, or nix.
 
+**MCP mode (prototype, opt-in):** agent-browser v0.28.0+ ships a typed stdio MCP server (`agent-browser mcp --tools <profile>`). Set `AGENT_BROWSER_MCP=<profile>` (e.g. `core`, or `core,network,react`) in an agent's `env` to register it as the `agent-browser` MCP server (tools surface as `mcp__agent-browser__*`) instead of the default Bash interface. When enabled, agent-runner swaps the system-prompt guidance to the MCP tools, skips loading the redundant `core` SKILL.md, and auto-allowlists `mcp__agent-browser__*` for tool-restricted agents. Empty/unset = unchanged Bash behavior. Context cost is roughly a wash (`core` SKILL.md ≈ 5.0k tokens vs `core` MCP profile ≈ 5.1k tokens / 28 tools, both cacheable), so the trade-off is typed-tool robustness vs the battle-tested Bash path — measure before flipping the default. Implemented in `agent-runner/src/index.ts` (`AGENT_BROWSER_MCP`, `USE_AGENT_BROWSER_MCP`).
+
 ## What it supports
 
 - Telegram I/O - Message Claude from your phone

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -315,24 +315,20 @@ Each MCP tool domain lives in its own file under `agent-runner/src/mcp-*.ts`. To
 
 ## Browser Automation (agent-browser)
 
-All agent containers include [agent-browser](https://github.com/vercel-labs/agent-browser) and are configured to use the system Chromium on Debian. Agents interact with browsers via Bash commands (more token-efficient than MCP).
+All agent containers include [agent-browser](https://github.com/vercel-labs/agent-browser) and are configured to use the system Chromium on Debian. Agents drive the browser exclusively through agent-browser's typed **MCP server** (`agent-browser mcp`, v0.28.0+) — the older Bash-command interface and its `core` usage-guide skill were removed after the MCP path was verified to produce byte-identical results at the same context cost (~5k tokens, cacheable).
 
 **Build-time setup** (`Dockerfile.agent-base`):
 - The prebuilt `agent-browser` binary is downloaded from the GitHub release (pinned by `AGENT_BROWSER_VERSION`) to `/usr/local/bin/agent-browser` and verified against SHA-256
-- The `core` skill (renamed from `agent-browser` in v0.26.0) is fetched from `skill-data/core/` and installed to `/usr/local/share/agent-browser/skills/core/`, together with its `references/` and `templates/`
-- A `config.json` is generated at `/usr/local/share/agent-browser/config.json` pointing to system Chromium at `/usr/bin/chromium`
+- A `config.json` is generated at `/usr/local/share/agent-browser/config.json` pointing to system Chromium at `/usr/bin/chromium` (the usage-guide skill is no longer fetched — the MCP server provides tool schemas directly)
 
 **Runtime setup** (`agent-runner/src/index.ts` → `setupAgentBrowser()`):
-- Symlinks `/usr/local/share/agent-browser/skills/core` → `/home/praktor/.claude/skills/core` (skill loaded into system prompt)
 - Symlinks `/usr/local/share/agent-browser/config.json` → `/home/praktor/.agent-browser/config.json` (agent-browser resolves config from `~/.agent-browser/`)
 - Symlinks (not copies) ensure agents always use the image's version — updates come from rebuilding the image
-- Cleans up stale symlinks from previous image versions (e.g. the old `playwright-cli` and `agent-browser` skill links)
+- Cleans up stale skill symlinks from previous image versions (`playwright-cli`, the old `agent-browser` skill, and the `core` usage-guide skill)
 
 **Browser lifecycle:** The browser session persists across messages within the same agent session. Everything shuts down with the container on idle timeout.
 
-**System prompt:** When `/usr/local/bin/agent-browser` exists, a prompt section tells agents that agent-browser is pre-installed and to never install browsers via npm, npx, or nix.
-
-**MCP mode (prototype, opt-in):** agent-browser v0.28.0+ ships a typed stdio MCP server (`agent-browser mcp --tools <profile>`). Set `AGENT_BROWSER_MCP=<profile>` (e.g. `core`, or `core,network,react`) in an agent's `env` to register it as the `agent-browser` MCP server (tools surface as `mcp__agent-browser__*`) instead of the default Bash interface. When enabled, agent-runner swaps the system-prompt guidance to the MCP tools, skips loading the redundant `core` SKILL.md, and auto-allowlists `mcp__agent-browser__*` for tool-restricted agents. Empty/unset = unchanged Bash behavior. Context cost is roughly a wash (`core` SKILL.md ≈ 5.0k tokens vs `core` MCP profile ≈ 5.1k tokens / 28 tools, both cacheable), so the trade-off is typed-tool robustness vs the battle-tested Bash path — measure before flipping the default. Implemented in `agent-runner/src/index.ts` (`AGENT_BROWSER_MCP`, `USE_AGENT_BROWSER_MCP`).
+**MCP server** (`agent-runner/src/index.ts`): `agent-browser mcp --tools <profile>` is registered as the `agent-browser` MCP server, so tools surface as `mcp__agent-browser__*`. The tool profile defaults to `core` and is overridable per-agent via `AGENT_BROWSER_MCP` in the agent's `env` (composable, e.g. `core,network,react` — see `agent-browser mcp --help`). The system prompt points agents at the `agent_browser_*` tools, and `mcp__agent-browser__*` is auto-allowlisted for tool-restricted agents. A prompt section also tells agents that agent-browser is pre-installed and to never install browsers via npm, npx, or nix.
 
 ## What it supports
 
@@ -348,7 +344,7 @@ All agent containers include [agent-browser](https://github.com/vercel-labs/agen
 - File receiving - Files sent to the bot in Telegram (documents, photos, audio, video, voice, video notes, animations) are downloaded and saved to the agent's workspace at `/workspace/agent/uploads/{timestamp}_{filename}`. The agent receives the file path in the message. Supports Telegram's 20MB download limit.
 - Voice transcription (STT) - Voice messages and video notes are automatically transcribed to text via OpenAI Whisper API. Agents receive `[Voice message] <transcribed text>` instead of raw audio files. Requires `OPENAI_API_KEY`. Falls back to file attachment on transcription failure.
 - Voice responses (TTS) - When `speech.tts_enabled` is true, agent responses can be sent back as Telegram voice messages via OpenAI TTS API. `tts_mode`: `"voice"` (respond with voice only when user sends voice), `"always"` (all responses), `"never"` (disabled). Configurable voice (alloy, echo, fable, onyx, nova, shimmer).
-- Browser automation - [agent-browser](https://github.com/vercel-labs/agent-browser) pre-installed with system Chromium, skill auto-loaded into system prompt. Browser session persists across messages, shuts down with container.
+- Browser automation - [agent-browser](https://github.com/vercel-labs/agent-browser) pre-installed with system Chromium, exposed as typed `mcp__agent-browser__*` MCP tools. Browser session persists across messages, shuts down with container.
 - Container isolation - Agents sandboxed in Docker containers with NATS communication
 - Agent swarms - Graph-based orchestration: fan-out (parallel), pipeline (sequential with context passing), and collaborative (real-time chat) execution patterns. Visual graph editor in Mission Control, `@swarm` Telegram integration
 - Secure vault - AES-256-GCM encrypted secrets, injected as env vars or files at container start (never exposed to LLM)

--- a/Dockerfile.agent-base
+++ b/Dockerfile.agent-base
@@ -82,14 +82,14 @@ RUN NPM_GLOBAL=$(npm root -g) && \
       > onnxruntime-node/index.js
 
 # Install agent-browser binary from GitHub release
-ARG AGENT_BROWSER_VERSION=v0.27.2
+ARG AGENT_BROWSER_VERSION=v0.28.0
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then \
       AB_ARCH="linux-x64"; \
-      AB_SHA256="cfc158bf92ea92780c67909777739ed47c25d8ad2f0161de5ef85e0d545d92fc"; \
+      AB_SHA256="c0bef69599d6ed123bf147bd6747755978330948d2ef5eaae492ef171b659556"; \
     elif [ "$ARCH" = "arm64" ]; then \
       AB_ARCH="linux-arm64"; \
-      AB_SHA256="3350efa628cd24b6a93228269daf71acd23c355ee04373c5c13d372ae0d5a936"; \
+      AB_SHA256="cceff680589c78b8582b425f4dc44b14179546d09b84c61b62dc5265baba7463"; \
     else \
       echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \

--- a/Dockerfile.agent-base
+++ b/Dockerfile.agent-base
@@ -98,21 +98,10 @@ RUN ARCH=$(dpkg --print-architecture) && \
     echo "${AB_SHA256}  /usr/local/bin/agent-browser" | sha256sum -c - && \
     chmod 555 /usr/local/bin/agent-browser
 
-# Download agent-browser skill and config. In v0.26.0 the usage guide moved
-# from skills/agent-browser/ to skill-data/core/ and was renamed to `core`.
-RUN mkdir -p /usr/local/share/agent-browser/skills/core/references \
-             /usr/local/share/agent-browser/skills/core/templates && \
-    cd /usr/local/share/agent-browser/skills/core && \
-    BASE="https://raw.githubusercontent.com/vercel-labs/agent-browser/${AGENT_BROWSER_VERSION}/skill-data/core" && \
-    curl -fsSL -O "${BASE}/SKILL.md" && \
-    cd references && \
-    for f in authentication commands profiling proxy-support session-management snapshot-refs trust-boundaries video-recording; do \
-      curl -fsSL -O "${BASE}/references/${f}.md"; \
-    done && \
-    cd ../templates && \
-    for f in authenticated-session capture-workflow form-automation; do \
-      curl -fsSL -O "${BASE}/templates/${f}.sh"; \
-    done && \
+# Generate agent-browser config pointing at the system Chromium. Agents drive
+# the browser through `agent-browser mcp` (typed tools), so the usage-guide
+# skill (skill-data/core SKILL.md + references + templates) is not fetched.
+RUN mkdir -p /usr/local/share/agent-browser && \
     echo '{"contentBoundaries":true,"downloadPath":"/workspace/agent/Downloads","executablePath":"/usr/bin/chromium","args":"--disable-gpu,--disable-dev-shm-usage"}' \
       > /usr/local/share/agent-browser/config.json
 

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -27,13 +27,12 @@ const ALLOWED_TOOLS_ENV = process.env.ALLOWED_TOOLS || "";
 const MAX_TURNS = parseInt(process.env.MAX_TURNS || "200", 10);
 const SWARM_CHAT_TOPIC = process.env.SWARM_CHAT_TOPIC || "";
 const SWARM_ROLE = process.env.SWARM_ROLE || "";
-// PROTOTYPE (agent-browser v0.28.0): opt into the typed MCP server instead of
-// the default Bash-command interface. Set to a tool-profile string
-// (e.g. "core" or "core,network,react") via an agent's env config. Empty =
-// keep the default Bash + SKILL.md path. See agent-browser mcp --help.
-const AGENT_BROWSER_MCP = (process.env.AGENT_BROWSER_MCP || "").trim();
+// agent-browser is driven through its typed MCP server (v0.28.0+).
+// AGENT_BROWSER_MCP selects the tool profile passed to `agent-browser mcp
+// --tools` (default "core"; composable, e.g. "core,network,react").
+// See `agent-browser mcp --help`.
 const AGENT_BROWSER_INSTALLED = existsSync("/usr/local/bin/agent-browser");
-const USE_AGENT_BROWSER_MCP = AGENT_BROWSER_MCP !== "" && AGENT_BROWSER_INSTALLED;
+const AGENT_BROWSER_MCP_TOOLS = (process.env.AGENT_BROWSER_MCP || "core").trim() || "core";
 
 let bridge: NatsBridge;
 let isProcessing = false;
@@ -148,20 +147,22 @@ function ensureAgentMd(): void {
 }
 
 function setupAgentBrowser(): void {
-  // In agent-browser v0.26.0 the usage-guide skill was renamed from
-  // `agent-browser` to `core` and moved to skill-data/core/.
-  const skillSource = "/usr/local/share/agent-browser/skills/core";
+  // agent-browser is driven via its typed MCP server, so no usage-guide skill
+  // is injected — only the config symlink (chromium path) is needed.
   const configSource = "/usr/local/share/agent-browser/config.json";
-  if (!existsSync(skillSource)) return; // agent-browser not installed
+  if (!AGENT_BROWSER_INSTALLED) return;
 
   try {
     const skillsDir = "/home/praktor/.claude/skills";
     mkdirSync(skillsDir, { recursive: true });
 
-    // Remove stale symlinks from previous image versions
+    // Remove stale skill symlinks from previous image versions (the old
+    // playwright-cli / agent-browser links, and the `core` usage-guide skill
+    // that earlier versions injected before the switch to the MCP server).
     for (const [name, target] of [
       ["playwright-cli", "/opt/playwright-cli/skill"],
       ["agent-browser", "/usr/local/share/agent-browser/skills/agent-browser"],
+      ["core", "/usr/local/share/agent-browser/skills/core"],
     ] as const) {
       const staleLink = join(skillsDir, name);
       try {
@@ -172,11 +173,6 @@ function setupAgentBrowser(): void {
       } catch { /* doesn't exist */ }
     }
 
-    // Force-update skill symlink
-    const skillLink = join(skillsDir, "core");
-    try { unlinkSync(skillLink); } catch { /* doesn't exist */ }
-    symlinkSync(skillSource, skillLink);
-
     // Force-update config symlink
     const configDir = "/home/praktor/.agent-browser";
     mkdirSync(configDir, { recursive: true });
@@ -184,7 +180,7 @@ function setupAgentBrowser(): void {
     try { unlinkSync(configLink); } catch { /* doesn't exist */ }
     symlinkSync(configSource, configLink);
 
-    console.log("[agent] agent-browser configured");
+    console.log("[agent] agent-browser configured (MCP)");
   } catch (err) {
     console.warn("[agent] could not configure agent-browser:", err);
   }
@@ -342,29 +338,17 @@ function loadSystemPrompt(includeIdentity = true): string {
     console.warn("[agent] could not load memory keys:", err);
   }
 
-  // agent-browser: inform agent it's pre-installed with system chromium.
-  // Two interfaces: the default Bash commands, or (prototype) the typed MCP
-  // server selected via AGENT_BROWSER_MCP.
+  // agent-browser: inform agent it's pre-installed (system chromium) and
+  // exposed through its typed MCP tools.
   if (AGENT_BROWSER_INSTALLED) {
-    if (USE_AGENT_BROWSER_MCP) {
-      parts.push(
-        "AGENT-BROWSER — Pre-installed, using the typed MCP interface. Do NOT install browsers via npm, npx, nix, or any other method.\n" +
-        "- Browser automation is exposed as `mcp__agent-browser__agent_browser_*` tools (configured to use the system Chromium).\n" +
-        "- Use `agent_browser_open` to start a session, then `agent_browser_snapshot` to see the page.\n" +
-        "- Do NOT call the `agent-browser` CLI via Bash — use the MCP tools instead.\n" +
-        "- The browser persists across messages. Reuse the existing session.\n" +
-        "- When executing a scheduled task, ALWAYS call `agent_browser_close` when done to free resources."
-      );
-    } else {
-      parts.push(
-        "AGENT-BROWSER — Pre-installed and configured. Do NOT install browsers via npm, npx, nix, or any other method.\n" +
-        "- `agent-browser` is already in PATH and ready to use.\n" +
-        "- It is configured to use the system Chromium.\n" +
-        "- Run `agent-browser open <url>` to start a browser session, then `agent-browser snapshot -i` to see the page.\n" +
-        "- The browser persists across messages. Reuse the existing session.\n" +
-        "- When executing a scheduled task, ALWAYS run `agent-browser close` when done to free resources."
-      );
-    }
+    parts.push(
+      "AGENT-BROWSER — Pre-installed, exposed as typed MCP tools. Do NOT install browsers via npm, npx, nix, or any other method.\n" +
+      "- Browser automation is available as `mcp__agent-browser__agent_browser_*` tools (configured to use the system Chromium).\n" +
+      "- Use `agent_browser_open` to start a session, then `agent_browser_snapshot` to see the page.\n" +
+      "- Do NOT call the `agent-browser` CLI via Bash — use the MCP tools instead.\n" +
+      "- The browser persists across messages. Reuse the existing session.\n" +
+      "- When executing a scheduled task, ALWAYS call `agent_browser_close` when done to free resources."
+    );
   }
 
   // AgentMail: inbox-locked restrictions when configured
@@ -389,9 +373,6 @@ function loadSystemPrompt(includeIdentity = true): string {
       const entries = readdirSync(skillsDir, { withFileTypes: true });
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
-        // In MCP mode the agent-browser `core` skill is redundant with the
-        // typed tool schemas — skip it so we don't pay for both.
-        if (USE_AGENT_BROWSER_MCP && entry.name === "core") continue;
         const skillMd = join(skillsDir, entry.name, "SKILL.md");
         try {
           const content = readFileSync(skillMd, "utf-8");
@@ -419,9 +400,9 @@ function buildRunOptions(sessionId?: string) {
   const systemPrompt = loadSystemPrompt();
   const cwd = "/workspace/agent";
   const tools = parseAllowedTools(ALLOWED_TOOLS_ENV);
-  // If tools are restricted and the agent-browser MCP is on, make sure its
-  // typed tools are allowlisted (the praktor-* wildcard wouldn't cover them).
-  if (tools && USE_AGENT_BROWSER_MCP && !tools.includes("mcp__agent-browser__*")) {
+  // If tools are restricted, make sure the agent-browser MCP tools are
+  // allowlisted (the praktor-* wildcard wouldn't cover them).
+  if (tools && AGENT_BROWSER_INSTALLED && !tools.includes("mcp__agent-browser__*")) {
     tools.push("mcp__agent-browser__*");
   }
 
@@ -475,13 +456,13 @@ function buildRunOptions(sessionId?: string) {
       env: { NATS_URL, AGENT_ID, SWARM_CHAT_TOPIC },
     };
   }
-  // PROTOTYPE: agent-browser typed MCP server (v0.28.0+), opt-in via
-  // AGENT_BROWSER_MCP=<profile>. Tools surface as mcp__agent-browser__*.
-  if (USE_AGENT_BROWSER_MCP) {
+  // agent-browser typed MCP server (v0.28.0+). Tools surface as
+  // mcp__agent-browser__*; profile selected by AGENT_BROWSER_MCP (default core).
+  if (AGENT_BROWSER_INSTALLED) {
     mcpServers["agent-browser"] = {
       type: "stdio",
       command: "/usr/local/bin/agent-browser",
-      args: ["mcp", "--tools", AGENT_BROWSER_MCP],
+      args: ["mcp", "--tools", AGENT_BROWSER_MCP_TOOLS],
       env: {},
     };
   }

--- a/agent-runner/src/index.ts
+++ b/agent-runner/src/index.ts
@@ -27,6 +27,13 @@ const ALLOWED_TOOLS_ENV = process.env.ALLOWED_TOOLS || "";
 const MAX_TURNS = parseInt(process.env.MAX_TURNS || "200", 10);
 const SWARM_CHAT_TOPIC = process.env.SWARM_CHAT_TOPIC || "";
 const SWARM_ROLE = process.env.SWARM_ROLE || "";
+// PROTOTYPE (agent-browser v0.28.0): opt into the typed MCP server instead of
+// the default Bash-command interface. Set to a tool-profile string
+// (e.g. "core" or "core,network,react") via an agent's env config. Empty =
+// keep the default Bash + SKILL.md path. See agent-browser mcp --help.
+const AGENT_BROWSER_MCP = (process.env.AGENT_BROWSER_MCP || "").trim();
+const AGENT_BROWSER_INSTALLED = existsSync("/usr/local/bin/agent-browser");
+const USE_AGENT_BROWSER_MCP = AGENT_BROWSER_MCP !== "" && AGENT_BROWSER_INSTALLED;
 
 let bridge: NatsBridge;
 let isProcessing = false;
@@ -335,16 +342,29 @@ function loadSystemPrompt(includeIdentity = true): string {
     console.warn("[agent] could not load memory keys:", err);
   }
 
-  // agent-browser: inform agent it's pre-installed with system chromium
-  if (existsSync("/usr/local/bin/agent-browser")) {
-    parts.push(
-      "AGENT-BROWSER — Pre-installed and configured. Do NOT install browsers via npm, npx, nix, or any other method.\n" +
-      "- `agent-browser` is already in PATH and ready to use.\n" +
-      "- It is configured to use the system Chromium.\n" +
-      "- Run `agent-browser open <url>` to start a browser session, then `agent-browser snapshot -i` to see the page.\n" +
-      "- The browser persists across messages. Reuse the existing session.\n" +
-      "- When executing a scheduled task, ALWAYS run `agent-browser close` when done to free resources."
-    );
+  // agent-browser: inform agent it's pre-installed with system chromium.
+  // Two interfaces: the default Bash commands, or (prototype) the typed MCP
+  // server selected via AGENT_BROWSER_MCP.
+  if (AGENT_BROWSER_INSTALLED) {
+    if (USE_AGENT_BROWSER_MCP) {
+      parts.push(
+        "AGENT-BROWSER — Pre-installed, using the typed MCP interface. Do NOT install browsers via npm, npx, nix, or any other method.\n" +
+        "- Browser automation is exposed as `mcp__agent-browser__agent_browser_*` tools (configured to use the system Chromium).\n" +
+        "- Use `agent_browser_open` to start a session, then `agent_browser_snapshot` to see the page.\n" +
+        "- Do NOT call the `agent-browser` CLI via Bash — use the MCP tools instead.\n" +
+        "- The browser persists across messages. Reuse the existing session.\n" +
+        "- When executing a scheduled task, ALWAYS call `agent_browser_close` when done to free resources."
+      );
+    } else {
+      parts.push(
+        "AGENT-BROWSER — Pre-installed and configured. Do NOT install browsers via npm, npx, nix, or any other method.\n" +
+        "- `agent-browser` is already in PATH and ready to use.\n" +
+        "- It is configured to use the system Chromium.\n" +
+        "- Run `agent-browser open <url>` to start a browser session, then `agent-browser snapshot -i` to see the page.\n" +
+        "- The browser persists across messages. Reuse the existing session.\n" +
+        "- When executing a scheduled task, ALWAYS run `agent-browser close` when done to free resources."
+      );
+    }
   }
 
   // AgentMail: inbox-locked restrictions when configured
@@ -369,6 +389,9 @@ function loadSystemPrompt(includeIdentity = true): string {
       const entries = readdirSync(skillsDir, { withFileTypes: true });
       for (const entry of entries) {
         if (!entry.isDirectory()) continue;
+        // In MCP mode the agent-browser `core` skill is redundant with the
+        // typed tool schemas — skip it so we don't pay for both.
+        if (USE_AGENT_BROWSER_MCP && entry.name === "core") continue;
         const skillMd = join(skillsDir, entry.name, "SKILL.md");
         try {
           const content = readFileSync(skillMd, "utf-8");
@@ -396,6 +419,11 @@ function buildRunOptions(sessionId?: string) {
   const systemPrompt = loadSystemPrompt();
   const cwd = "/workspace/agent";
   const tools = parseAllowedTools(ALLOWED_TOOLS_ENV);
+  // If tools are restricted and the agent-browser MCP is on, make sure its
+  // typed tools are allowlisted (the praktor-* wildcard wouldn't cover them).
+  if (tools && USE_AGENT_BROWSER_MCP && !tools.includes("mcp__agent-browser__*")) {
+    tools.push("mcp__agent-browser__*");
+  }
 
   // Annotated const so contextual typing narrows `type: "stdio"` on each
   // entry to the literal "stdio" expected by McpStdioServerConfig (a plain
@@ -445,6 +473,16 @@ function buildRunOptions(sessionId?: string) {
       command: "node",
       args: ["/app/mcp-swarm.mjs"],
       env: { NATS_URL, AGENT_ID, SWARM_CHAT_TOPIC },
+    };
+  }
+  // PROTOTYPE: agent-browser typed MCP server (v0.28.0+), opt-in via
+  // AGENT_BROWSER_MCP=<profile>. Tools surface as mcp__agent-browser__*.
+  if (USE_AGENT_BROWSER_MCP) {
+    mcpServers["agent-browser"] = {
+      type: "stdio",
+      command: "/usr/local/bin/agent-browser",
+      args: ["mcp", "--tools", AGENT_BROWSER_MCP],
+      env: {},
     };
   }
 


### PR DESCRIPTION
## Summary

Bump agent-browser to **v0.28.0** and switch the browser interface entirely to its new typed **MCP server** (`agent-browser mcp`), removing the legacy Bash-command path and the injected `core` usage-guide skill.

## Why

praktor originally used Bash because it was *"more token-efficient than MCP"*. v0.28.0's `core` tool profile is built to fix exactly that. Measured + verified end-to-end against `https://mtzanidakis.com`:

| | Bash | MCP (`core`) |
|---|---|---|
| Context cost | ~5.0k tokens (SKILL.md) | ~5.1k tokens (28 typed tools) |
| Screenshot bytes | 56,113 | 56,113 |
| Screenshot sha256 | `770383c2…` | `770383c2…` **(identical)** |

The token rationale is gone (a wash, both cacheable) and the two interfaces produce **byte-identical** output — so MCP wins on typed-tool robustness with no downside. Bash is removed rather than kept as a fallback.

## Changes

- **`Dockerfile.agent-base`**: agent-browser `v0.27.2` → **`v0.28.0`** (new SHA-256 for both arches, verified). Stop fetching the `skill-data/core` usage guide (SKILL.md + 8 references + 3 templates) — the MCP server provides tool schemas directly. Only `config.json` is generated.
- **`agent-runner/src/index.ts`**: always register `agent-browser mcp --tools <profile>` as the `agent-browser` MCP server (tools surface as `mcp__agent-browser__*`). Profile defaults to `core`, overridable per-agent via `AGENT_BROWSER_MCP` (e.g. `core,network,react`). System prompt points agents at the `agent_browser_*` tools; `mcp__agent-browser__*` auto-allowlisted for tool-restricted agents. Removed the Bash branch, the `USE_AGENT_BROWSER_MCP`/bash-mode toggles, the dual system prompt, and the `core` SKILL.md injection. `setupAgentBrowser` now only symlinks `config.json` and cleans up the stale `core` skill link.
- **`CLAUDE.md`**: documents the MCP-only path.

## Verification

- `tsc --noEmit` clean; **66/66 vitest** pass; esbuild bundles.
- Rebuilt base + agent images (skill download removed): binary v0.28.0 present, `config.json` present, `skills/core` **gone**.
- Bundle wires `agent-browser mcp --tools`, MCP system-prompt present, old Bash `open <url>` guidance gone.
- Final end-to-end on the shipping image under full Balanced hardening (`cap-drop ALL`, `no-new-privileges`): **no `core` skill injected**, MCP `open`/`screenshot`/`close` all `isError:false`, screenshot sha256 `770383c2…` — **byte-identical** to the earlier Bash and MCP runs.

## Note

Base-image change → needs a `praktor-agent-base` rebuild + GHCR push to reach agents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)