### PR TITLE
fix(security): prevent upload filename path traversal out of uploads/

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,40 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities **privately**. Do not open a public
+issue, pull request, or discussion for security problems.
+
+Preferred channel: **GitHub private vulnerability reporting**. Go to the
+repository's **Security** tab → **Report a vulnerability**, or use the
+[advisories page](https://github.com/mtzanidakis/praktor/security/advisories/new).
+
+Alternatively, email **mtzanidakis@gmail.com** with:
+
+- a description of the issue and its impact,
+- the affected version or commit (`praktor version`),
+- steps to reproduce (a minimal proof of concept is appreciated), and
+- any suggested remediation.
+
+## What to Expect
+
+- **Acknowledgement** of your report within **5 business days**.
+- A **triage assessment** (severity, affected versions) within **10 business days**.
+- Coordinated disclosure: we will agree on a timeline with you before any public
+  disclosure. Our default target is to ship a fix within **90 days** of triage,
+  sooner for high-severity issues.
+- **Credit**: reporters are credited in the release notes and/or the published
+  advisory unless they prefer to remain anonymous.
+
+## Scope
+
+Praktor routes messages to Claude Code agents running in isolated Docker
+containers. Reports that are especially in scope include:
+
+- breaking the agent container / workspace isolation boundary,
+- secret/vault exposure,
+- authentication or authorization bypass in the Web UI or API,
+- remote-triggerable code execution or injection (including prompt/instruction
+  injection that escapes the intended task boundary).
+
+Thank you for helping keep Praktor and its users safe.

--- a/internal/container/manager.go
+++ b/internal/container/manager.go
@@ -577,8 +577,13 @@ func (m *Manager) WriteVolumeBytes(ctx context.Context, workspace, filePath stri
 	var buf bytes.Buffer
 	tw := tar.NewWriter(&buf)
 
-	targetPath := path.Join("/vol", filePath)
-	targetPath = strings.TrimPrefix(targetPath, "/")
+	// Defense-in-depth: reject any filePath that escapes /vol after path.Join
+	// collapses "../" sequences (e.g. a traversal-laden upload filename).
+	cleaned := path.Join("/vol", filePath)
+	if cleaned != "/vol" && !strings.HasPrefix(cleaned, "/vol/") {
+		return fmt.Errorf("invalid file path %q: escapes volume root", filePath)
+	}
+	targetPath := strings.TrimPrefix(cleaned, "/")
 
 	// Create parent directory entries with correct ownership
 	parts := strings.Split(path.Dir(targetPath), "/")

--- a/internal/telegram/bot.go
+++ b/internal/telegram/bot.go
@@ -425,7 +425,7 @@ func (b *Bot) processMediaGroup(ctx context.Context, msgs []telego.Message) {
 			slog.Error("file download failed", "file_id", att.FileID, "error", err)
 			continue
 		}
-		volumePath := fmt.Sprintf("uploads/%d_%s", time.Now().UnixNano(), att.Name)
+		volumePath := fmt.Sprintf("uploads/%d_%s", time.Now().UnixNano(), path.Base(att.Name))
 		containerPath := "/workspace/agent/" + volumePath
 		if err := b.orch.WriteVolumeBytes(ctx, ag.Workspace, volumePath, data, image); err != nil {
 			slog.Error("file write to volume failed", "path", volumePath, "error", err)
@@ -565,7 +565,7 @@ func (b *Bot) processMessage(ctx context.Context, msg telego.Message) {
 			}
 
 			image := b.registry.ResolveImage(agentID)
-			volumePath := fmt.Sprintf("uploads/%d_%s", time.Now().Unix(), attachment.Name)
+			volumePath := fmt.Sprintf("uploads/%d_%s", time.Now().Unix(), path.Base(attachment.Name))
 			containerPath := "/workspace/agent/" + volumePath
 
 			if err := b.orch.WriteVolumeBytes(ctx, ag.Workspace, volumePath, data, image); err != nil {


### PR DESCRIPTION
## Summary

Fixes a path-traversal vulnerability reported privately by **tonghuaroot** (GitHub).

A Telegram document upload's client-controlled filename was concatenated into the destination path without sanitization (`bot.go:428`, `bot.go:568`) and resolved with `path.Join`, which collapses `../`. A filename like `../../../CLAUDE.md` escaped the documented `uploads/` directory and landed at the agent workspace volume root (`/workspace/agent`), letting a remote Telegram user plant/overwrite files the agent later consumes — a stored instruction-injection vector. With the default empty `allow_from` (allow-all), this is reachable by any user who can message the bot.

## Fix (defense in depth)

- **`internal/telegram/bot.go`** — apply `path.Base()` to the attacker-controlled filename at both upload sites, stripping directory components and `..`.
- **`internal/container/manager.go`** — `WriteVolumeBytes` now rejects any path that escapes `/vol` after `path.Join`, protecting future callers.
- **`SECURITY.md`** — added a security policy (private reporting + coordinated disclosure). Private vulnerability reporting has also been enabled on the repo.

## Verification

Reproduced end-to-end against a real Docker daemon driving the production `container.Manager` methods: before the fix, a `../../../X` filename landed at `/vol/X` (volume root); after the fix it lands only under `uploads/`, and a genuinely volume-escaping path is rejected with `escapes volume root`.