### PR TITLE
chore: bump claude cli 2.1.193 and agent-browser v0.31.0

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -10,7 +10,7 @@ RUN node esbuild.mjs
 
 FROM ghcr.io/mtzanidakis/praktor-agent-base:latest
 COPY --from=agent-builder /app/out/ /app/
-RUN /usr/local/bin/getcc -get-version 2.1.183 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
+RUN /usr/local/bin/getcc -get-version 2.1.193 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
 USER praktor
 WORKDIR /workspace/agent
 ENTRYPOINT ["tini", "--", "node", "/app/index.mjs"]

--- a/Dockerfile.agent-base
+++ b/Dockerfile.agent-base
@@ -82,14 +82,14 @@ RUN NPM_GLOBAL=$(npm root -g) && \
       > onnxruntime-node/index.js
 
 # Install agent-browser binary from GitHub release
-ARG AGENT_BROWSER_VERSION=v0.28.0
+ARG AGENT_BROWSER_VERSION=v0.31.0
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then \
       AB_ARCH="linux-x64"; \
-      AB_SHA256="c0bef69599d6ed123bf147bd6747755978330948d2ef5eaae492ef171b659556"; \
+      AB_SHA256="71dbe415ab3ded286c71eca67933575eb9f451be9155283a2e3a1ab878d75eff"; \
     elif [ "$ARCH" = "arm64" ]; then \
       AB_ARCH="linux-arm64"; \
-      AB_SHA256="cceff680589c78b8582b425f4dc44b14179546d09b84c61b62dc5265baba7463"; \
+      AB_SHA256="bb2827dede43536e402cba8bc74249cdaa5af9aee291d185083c7bbdb7d62b14"; \
     else \
       echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \


### PR DESCRIPTION
## Summary

- **`Dockerfile.agent`** — Claude Code CLI `2.1.183` → `2.1.193`, matching the `@anthropic-ai/claude-agent-sdk` `0.3.193` bump from #227.
- **`Dockerfile.agent-base`** — agent-browser `v0.28.0` → `v0.31.0`, with refreshed `linux-x64` and `linux-arm64` SHA-256 checksums (computed from the downloaded release binaries).

## Changelog review (0.28 → 0.31)

All changes are additive — **no integration changes needed**:

- **0.29.0** — `@agent-browser/sandbox` helpers (npm package), unrelated to our deployment.
- **0.30.0** — new `read` command + matching MCP tool (text extraction).
- **0.31.0** — `--restore` / `--restore-save` / `session id|info` / `--namespace` flags for persistent, isolated browser state.

The `config.json` schema, the `agent-browser mcp --tools <profile>` invocation, and the `--tools` profiles are unchanged, so `setupAgentBrowser()` and the config generation in `Dockerfile.agent-base` need no updates.