### PR TITLE
chore: bump claude-agent-sdk 0.3.197, claude code 2.1.197, agent-browser v0.31.1

### DIFF
--- a/Dockerfile.agent
+++ b/Dockerfile.agent
@@ -10,7 +10,7 @@ RUN node esbuild.mjs
 
 FROM ghcr.io/mtzanidakis/praktor-agent-base:latest
 COPY --from=agent-builder /app/out/ /app/
-RUN /usr/local/bin/getcc -get-version 2.1.193 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
+RUN /usr/local/bin/getcc -get-version 2.1.197 -save /usr/local/bin/claude && chmod 555 /usr/local/bin/claude
 USER praktor
 WORKDIR /workspace/agent
 ENTRYPOINT ["tini", "--", "node", "/app/index.mjs"]

--- a/Dockerfile.agent-base
+++ b/Dockerfile.agent-base
@@ -82,14 +82,14 @@ RUN NPM_GLOBAL=$(npm root -g) && \
       > onnxruntime-node/index.js
 
 # Install agent-browser binary from GitHub release
-ARG AGENT_BROWSER_VERSION=v0.31.0
+ARG AGENT_BROWSER_VERSION=v0.31.1
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then \
       AB_ARCH="linux-x64"; \
-      AB_SHA256="71dbe415ab3ded286c71eca67933575eb9f451be9155283a2e3a1ab878d75eff"; \
+      AB_SHA256="72c13bcfd2fd6b188325bdd23c646d06ca69a1a964a9cdaab37e4ff8f47aa5c6"; \
     elif [ "$ARCH" = "arm64" ]; then \
       AB_ARCH="linux-arm64"; \
-      AB_SHA256="bb2827dede43536e402cba8bc74249cdaa5af9aee291d185083c7bbdb7d62b14"; \
+      AB_SHA256="5f80bff26b25e9a9f712be64dda1f8ea2b22213a1a07c0f97ea8f9f226c2894b"; \
     else \
       echo "Unsupported architecture: $ARCH" && exit 1; \
     fi && \

--- a/agent-runner/package-lock.json
+++ b/agent-runner/package-lock.json
@@ -8,34 +8,34 @@
       "name": "praktor-agent-runner",
       "version": "1.0.0",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "0.3.193",
+        "@anthropic-ai/claude-agent-sdk": "0.3.197",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "nats": "*"
+        "nats": "latest"
       },
       "devDependencies": {
-        "@types/node": "*",
-        "esbuild": "*",
-        "typescript": "*",
-        "vitest": "*"
+        "@types/node": "latest",
+        "esbuild": "latest",
+        "typescript": "latest",
+        "vitest": "latest"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.193.tgz",
-      "integrity": "sha512-WzL03VJE1sT0Nz3rEpsYMYR+9n6iyQtLVt7ghMWnYC9pvDsiy6kwcMplZniWSjH8Dm6CfkUBN5t6KB4i/JfouA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.197.tgz",
+      "integrity": "sha512-XNIi8W1tb+QfMkcK+5kepOC6BsxG8wtupd72H+pIPzIJypVQhHy7FoX+KBMtTRYwtl+5dsjKyABhjWXebeUilw==",
       "license": "SEE LICENSE IN README.md",
       "engines": {
         "node": ">=18.0.0"
       },
       "optionalDependencies": {
-        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.193",
-        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.193",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.193",
-        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.193",
-        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.193",
-        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.193",
-        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.193",
-        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.193"
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.197",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.197"
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.93.0",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.193.tgz",
-      "integrity": "sha512-1hT7b+KIm/3E1OSJofr7PF21Xq2zT1ccnjzuVcWQ5LYXJ09lgCMvA/ZfcDBKuoyCZ4lSnuicKXZ/h5vRbWfqrA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.197.tgz",
+      "integrity": "sha512-jC6WvH5Hr6APTfbMjo4nC6LlyMMqbpCMwiHXIw7/AsQXIHQhZ+cRRMesQlV6UFI1l3O53gLZHzsG9cXwfrPHKw==",
       "cpu": [
         "arm64"
       ],
@@ -57,9 +57,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.193.tgz",
-      "integrity": "sha512-9x5Y/L6iwETwEJFmPaYXfsE8q0cVgx75V7nL60HvSzi8K1XQNcG5u53jOzRvqDNah8mvGYOb+9AWrMCSJvmFyA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.197.tgz",
+      "integrity": "sha512-ZQNvGkMrTyatBlHTIQ4w2i2aLBuvq355UP/FDLnVXIH8l23RsL1x/0w9P+dqB7EmY9OZi/cPxSrpskpo+dZWLA==",
       "cpu": [
         "x64"
       ],
@@ -70,9 +70,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.193.tgz",
-      "integrity": "sha512-gvfD9pKHXWxCkkIX6bC4/FOALTxqHYjAu83iT1bzn5mCv6QWSZRl6WLRRtvKpWtWuY1jpML1lL3YfKADsAX/rA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.197.tgz",
+      "integrity": "sha512-pWhQgCtAft4EGM4Zn24HRad1a/k2u6oA+2uM/KCdjehfKtooDiHfMNd1yzXY/n9AEBWP0RHB2Vz3mJ30X2pVAg==",
       "cpu": [
         "arm64"
       ],
@@ -86,9 +86,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.193.tgz",
-      "integrity": "sha512-a3qsVTBe4G6ndsVavfIXEVAXLVXM8uvBUNYpm4jKqk2+ovWZQe/96CXOwmerg9U+/bllg4QJ9lSyYCsdtVIr6w==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.197.tgz",
+      "integrity": "sha512-VuIGXsLGK/aqSQ0tTBqqPVNzjefWS5SWnK8mlYyQitT4s5UDzHXJm0UZBTGxRtlcS0e2+QAHKwbGBCq1ZKSXjg==",
       "cpu": [
         "arm64"
       ],
@@ -102,9 +102,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.193.tgz",
-      "integrity": "sha512-1sz+7cn0iuh0ThInuAYF1jpFvLyOaZ0PZYQIF7eb9JDZbBohUf6INeTCwjAwUL0ASCq2xS7Odu/qDVuTtLTeDA==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.197.tgz",
+      "integrity": "sha512-AUccrbdcv4Hy/GteP/gYLjG/zDP+fe2BFtDMctEfRFVz40DazYDcOyW1+nIgSTQtxf5jSTAVVf3cNuXB2CZwlw==",
       "cpu": [
         "x64"
       ],
@@ -118,9 +118,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.193.tgz",
-      "integrity": "sha512-DLXlO4tlcWygz0Ft4nu6ai5KssByYt2tOeWdc4dFXKt6uBKXpbZVziUUq3ePO5zuAFyU6w7EjYLv8MMPURbAiQ==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.197.tgz",
+      "integrity": "sha512-3Tuy7XhD4UIKE4A4RPmKJcbL7Q/3dcB1hEWQt2lKP7c/DlixeEv+tRzvpnFZKhFX2hy0tkBk3QjkozSAacMC/w==",
       "cpu": [
         "x64"
       ],
@@ -134,9 +134,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.193.tgz",
-      "integrity": "sha512-36LJKiGuKusgaPTVeh9QanL00UcaE0RcC4pgK800/0SenApbh979ndxI0XKUVfLHzlGkqlhkhT3foMdqS+zx1w==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.197.tgz",
+      "integrity": "sha512-Wx8uiAKBenDuL8lWQmrqnX5ppljaH5unQ9cKiCz2/9Kgf09dgnrwbX8n/FhndCZR8PmYw539eWwYVrSVc/bl6w==",
       "cpu": [
         "arm64"
       ],
@@ -147,9 +147,9 @@
       ]
     },
     "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
-      "version": "0.3.193",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.193.tgz",
-      "integrity": "sha512-VyyKZlWQpbD6nkUTeNvgmLvpqt1QaPQQBOC30tbEYwYsV5MC1I35Li0H7nWwngGqPSTtMvHpjpz6Eb2FSTn7/A==",
+      "version": "0.3.197",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.197.tgz",
+      "integrity": "sha512-ZXJO/VvR3SI4G0gwthWeFXWdHB5RXPu3rtfGRcKZ/YgtDeW17rQ+LZIJTk2ywzbLb8EvlghR5JPgn293hC179Q==",
       "cpu": [
         "x64"
       ],

--- a/agent-runner/package.json
+++ b/agent-runner/package.json
@@ -10,7 +10,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "0.3.193",
+    "@anthropic-ai/claude-agent-sdk": "0.3.197",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "nats": "latest"
   },


### PR DESCRIPTION
Bumps:
- `@anthropic-ai/claude-agent-sdk` 0.3.193 → 0.3.197
- Claude Code (agent image) 2.1.193 → 2.1.197
- agent-browser v0.31.0 → v0.31.1 (SHA-256 verified for linux-x64 and linux-arm64)

Supersedes #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)