### PR TITLE
docs: update default model to claude-sonnet-5

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ telegram:
   main_chat_id: 0           # Chat ID for scheduled task / swarm results
 
 defaults:
-  model: "claude-sonnet-4-6"
+  model: "claude-sonnet-5"
   max_running: 5
   idle_timeout: 10m
 

--- a/config/praktor.example.yaml
+++ b/config/praktor.example.yaml
@@ -5,7 +5,7 @@ telegram:
 
 defaults:
   image: "praktor-agent:latest"
-  model: "claude-sonnet-4-6"           # Default Claude model for agents
+  model: "claude-sonnet-5"             # Default Claude model for agents
   max_running: 5
   idle_timeout: 10m
   anthropic_api_key: "${ANTHROPIC_API_KEY}"


### PR DESCRIPTION
Updates documentation default model `claude-sonnet-4-6` → `claude-sonnet-5` in `README.md` and `config/praktor.example.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)